### PR TITLE
Quiets apt-get update

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ sudo apt-get install -y rlwrap
 # Install emacs24
 # https://launchpad.net/~cassou/+archive/emacs
 sudo apt-add-repository -y ppa:cassou/emacs
-sudo apt-get update
+sudo apt-get -qq update
 sudo apt-get install -y emacs24 emacs24-el emacs24-common-non-dfsg
 
 # Install Heroku toolbelt


### PR DESCRIPTION
apt-get update produces a lot of noise on the command line and makes it hard to see if any errors may have occurred. By adding the -qq tag, apt-get update silences itself.

Noise still exists, but they are from remote scripts.
